### PR TITLE
Split read requests into chunks of 25 vars

### DIFF
--- a/examples/control.py
+++ b/examples/control.py
@@ -13,7 +13,7 @@ async def main():
     prefix = f"c{nad}."
     async with Cybro("solar-cybro.com/scgi/", 80, nad) as cybro:
         device = await cybro.update()
-        print(device.server_info.server_version)
+        print("server_version -> " + device.server_info.server_version)
         print("ip_port -> " + device.plc_info.ip_port)
         print("timestamp -> " + device.plc_info.timestamp)
         print("plc_program_status -> " + device.plc_info.plc_program_status)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cybro",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": true,
   "description": "Asynchronous Python client for Cybro Scgi Server",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cybro"
-version = "0.0.5"
+version = "0.0.6"
 description = "Asynchronous Python client for Cybro scgi server."
 authors = ["Daniel Gangl <killer007@gmx.at>"]
 maintainers = ["Daniel Gangl <killer007@gmx.at>"]


### PR DESCRIPTION
To have smaller requests to the scgi server we split the user vars into smaller chunks (currently a size of 25)