### PR TITLE
Add iex_card_id and firmware_version to hiq tags

### DIFF
--- a/src/cybro/cybro.py
+++ b/src/cybro/cybro.py
@@ -348,13 +348,18 @@ def _get_chunk(data, chunk_size):
 
 
 def _add_hiq_tags(
-    variables: dict[str, str], controller: str = "c10000."
+    variables: dict[str, str],
+    controller: str = "c10000.",
+    add_card_id: bool = False,
+    add_fw_ver: bool = False,
 ) -> dict[str, str]:
     """Adds controller specific general error tags.
 
     Args:
         variables: current list of variables to add to it
         controller: controller prefix (Default: c10000.)
+        add_card_id: append iex_card_id for HIQ expansion units
+        add_fw_ver: append firmware_version for HIQ expansion units
 
     Returns:
         An updated dictionary of variables that includes HIQ controller specific variables.
@@ -460,4 +465,95 @@ def _add_hiq_tags(
     _vars[controller + "water_temperature_enable"] = ""
     _vars[controller + "auxilary_temperature_enable"] = ""
     _vars[controller + "hvac_mode"] = ""
+    if add_card_id:
+        _vars[controller + "lc00_iex_card_id"] = ""
+        _vars[controller + "lc01_iex_card_id"] = ""
+        _vars[controller + "lc02_iex_card_id"] = ""
+        _vars[controller + "lc03_iex_card_id"] = ""
+        _vars[controller + "lc04_iex_card_id"] = ""
+        _vars[controller + "lc05_iex_card_id"] = ""
+        _vars[controller + "lc06_iex_card_id"] = ""
+        _vars[controller + "lc07_iex_card_id"] = ""
+        _vars[controller + "ld00_iex_card_id"] = ""
+        _vars[controller + "ld01_iex_card_id"] = ""
+        _vars[controller + "ld02_iex_card_id"] = ""
+        _vars[controller + "ld03_iex_card_id"] = ""
+        _vars[controller + "ld04_iex_card_id"] = ""
+        _vars[controller + "ld05_iex_card_id"] = ""
+        _vars[controller + "ld06_iex_card_id"] = ""
+        _vars[controller + "ld07_iex_card_id"] = ""
+        _vars[controller + "ld08_iex_card_id"] = ""
+        _vars[controller + "ld09_iex_card_id"] = ""
+        _vars[controller + "bc00_iex_card_id"] = ""
+        _vars[controller + "bc01_iex_card_id"] = ""
+        _vars[controller + "bc02_iex_card_id"] = ""
+        _vars[controller + "bc03_iex_card_id"] = ""
+        _vars[controller + "bc04_iex_card_id"] = ""
+        _vars[controller + "bc05_iex_card_id"] = ""
+        _vars[controller + "sc00_iex_card_id"] = ""
+        _vars[controller + "sc01_iex_card_id"] = ""
+        _vars[controller + "sc02_iex_card_id"] = ""
+        _vars[controller + "sc03_iex_card_id"] = ""
+        _vars[controller + "th00_iex_card_id"] = ""
+        _vars[controller + "th01_iex_card_id"] = ""
+        _vars[controller + "th02_iex_card_id"] = ""
+        _vars[controller + "th03_iex_card_id"] = ""
+        _vars[controller + "th04_iex_card_id"] = ""
+        _vars[controller + "th05_iex_card_id"] = ""
+        _vars[controller + "th06_iex_card_id"] = ""
+        _vars[controller + "th07_iex_card_id"] = ""
+        _vars[controller + "th08_iex_card_id"] = ""
+        _vars[controller + "th09_iex_card_id"] = ""
+        _vars[controller + "fc00_iex_card_id"] = ""
+        _vars[controller + "fc01_iex_card_id"] = ""
+        _vars[controller + "fc02_iex_card_id"] = ""
+        _vars[controller + "fc03_iex_card_id"] = ""
+        _vars[controller + "fc04_iex_card_id"] = ""
+        _vars[controller + "fc05_iex_card_id"] = ""
+    if add_fw_ver:
+        _vars[controller + "lc00_firmware_version"] = ""
+        _vars[controller + "lc01_firmware_version"] = ""
+        _vars[controller + "lc02_firmware_version"] = ""
+        _vars[controller + "lc03_firmware_version"] = ""
+        _vars[controller + "lc04_firmware_version"] = ""
+        _vars[controller + "lc05_firmware_version"] = ""
+        _vars[controller + "lc06_firmware_version"] = ""
+        _vars[controller + "lc07_firmware_version"] = ""
+        _vars[controller + "ld00_firmware_version"] = ""
+        _vars[controller + "ld01_firmware_version"] = ""
+        _vars[controller + "ld02_firmware_version"] = ""
+        _vars[controller + "ld03_firmware_version"] = ""
+        _vars[controller + "ld04_firmware_version"] = ""
+        _vars[controller + "ld05_firmware_version"] = ""
+        _vars[controller + "ld06_firmware_version"] = ""
+        _vars[controller + "ld07_firmware_version"] = ""
+        _vars[controller + "ld08_firmware_version"] = ""
+        _vars[controller + "ld09_firmware_version"] = ""
+        _vars[controller + "bc00_firmware_version"] = ""
+        _vars[controller + "bc01_firmware_version"] = ""
+        _vars[controller + "bc02_firmware_version"] = ""
+        _vars[controller + "bc03_firmware_version"] = ""
+        _vars[controller + "bc04_firmware_version"] = ""
+        _vars[controller + "bc05_firmware_version"] = ""
+        _vars[controller + "sc00_firmware_version"] = ""
+        _vars[controller + "sc01_firmware_version"] = ""
+        _vars[controller + "sc02_firmware_version"] = ""
+        _vars[controller + "sc03_firmware_version"] = ""
+        _vars[controller + "th00_firmware_version"] = ""
+        _vars[controller + "th01_firmware_version"] = ""
+        _vars[controller + "th02_firmware_version"] = ""
+        _vars[controller + "th03_firmware_version"] = ""
+        _vars[controller + "th04_firmware_version"] = ""
+        _vars[controller + "th05_firmware_version"] = ""
+        _vars[controller + "th06_firmware_version"] = ""
+        _vars[controller + "th07_firmware_version"] = ""
+        _vars[controller + "th08_firmware_version"] = ""
+        _vars[controller + "th09_firmware_version"] = ""
+        _vars[controller + "fc00_firmware_version"] = ""
+        _vars[controller + "fc01_firmware_version"] = ""
+        _vars[controller + "fc02_firmware_version"] = ""
+        _vars[controller + "fc03_firmware_version"] = ""
+        _vars[controller + "fc04_firmware_version"] = ""
+        _vars[controller + "fc05_firmware_version"] = ""
+
     return _vars

--- a/tests/test_cybro.py
+++ b/tests/test_cybro.py
@@ -356,6 +356,47 @@ class TestCybro(IsolatedAsyncioTestCase):
         _vars = _add_hiq_tags(_vars, "c1.")
         self.assertCountEqual(_vars, _vars_check)
 
+    def test_cybro_add_hiq_tags_all(self) -> None:
+        """Check to add hiq-tags."""
+        _vars_check = {}
+        for dev in range(8):
+            _vars_check.update({f"c1.lc{dev:02.0f}_general_error": ""})
+            _vars_check.update({f"c1.lc{dev:02.0f}_iex_card_id": ""})
+            _vars_check.update({f"c1.lc{dev:02.0f}_firmware_version": ""})
+        for dev in range(10):
+            _vars_check.update({f"c1.ld{dev:02.0f}_general_error": ""})
+            _vars_check.update({f"c1.ld{dev:02.0f}_rgb_mode": ""})
+            _vars_check.update({f"c1.ld{dev:02.0f}_rgb_mode_2": ""})
+            _vars_check.update({f"c1.ld{dev:02.0f}_iex_card_id": ""})
+            _vars_check.update({f"c1.ld{dev:02.0f}_firmware_version": ""})
+        for dev in range(4):
+            _vars_check.update({f"c1.sc{dev:02.0f}_general_error": ""})
+            _vars_check.update({f"c1.sc{dev:02.0f}_iex_card_id": ""})
+            _vars_check.update({f"c1.sc{dev:02.0f}_firmware_version": ""})
+        for dev in range(6):
+            _vars_check.update({f"c1.bc{dev:02.0f}_general_error": ""})
+            _vars_check.update({f"c1.bc{dev:02.0f}_iex_card_id": ""})
+            _vars_check.update({f"c1.bc{dev:02.0f}_firmware_version": ""})
+            _vars_check.update({f"c1.fc{dev:02.0f}_general_error": ""})
+            _vars_check.update({f"c1.fc{dev:02.0f}_iex_card_id": ""})
+            _vars_check.update({f"c1.fc{dev:02.0f}_firmware_version": ""})
+        for dev in range(10):
+            _vars_check.update({f"c1.th{dev:02.0f}_general_error": ""})
+            _vars_check.update({f"c1.th{dev:02.0f}_window_enable": ""})
+            _vars_check.update({f"c1.th{dev:02.0f}_fan_limit": ""})
+            _vars_check.update({f"c1.th{dev:02.0f}_demand_enable": ""})
+            _vars_check.update({f"c1.th{dev:02.0f}_iex_card_id": ""})
+            _vars_check.update({f"c1.th{dev:02.0f}_firmware_version": ""})
+        _vars_check.update({"c1.power_meter_error": ""})
+        _vars_check.update({"c1.outdoor_temperature_enable": ""})
+        _vars_check.update({"c1.wall_temperature_enable": ""})
+        _vars_check.update({"c1.water_temperature_enable": ""})
+        _vars_check.update({"c1.auxilary_temperature_enable": ""})
+        _vars_check.update({"c1.hvac_mode": ""})
+        _vars = {}
+        _vars = _add_hiq_tags(_vars, "c1.", True, True)
+        self.assertCountEqual(_vars, _vars_check)
+
     # We patch 'aiohttp.client.ClientSession' with our own method. The mock object is passed in to our test case method.
     # @patch("aiohttp.client.ClientSession", spec=True)
     # @mock.patch("aiohttp.client.ClientSession", side_effect=mocked_requests_get)


### PR DESCRIPTION
Add `iex_card_id` and `firmware_version` to list of prefetched tags.

Closes #180 